### PR TITLE
hotfix infinite loop 

### DIFF
--- a/src/Middlewares/PermissionMiddleware.php
+++ b/src/Middlewares/PermissionMiddleware.php
@@ -24,7 +24,7 @@ class PermissionMiddleware
             ? $permissions
             : explode('|', $permissions);
         foreach ($permissions as $permission)
-            if (Auth::user()->can($permission))
+            if (Auth::user()->hasPermission($permission))
                 return $next($request);
         throw UnauthorizedException::forPermissions();
     }


### PR DESCRIPTION
`Auth::user()->can($permission)` causes infinite loop when check permission.
Replased with hasPermission().