### PR TITLE
Fix #62, Fix #61

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to `mateusjunges/laravel-acl` will be documented in this file.
 
+## 1.5.2
+
+- Fix [#61](https://github.com/mateusjunges/laravel-acl/issues/61)
+- Fix [#62](https://github.com/mateusjunges/laravel-acl/issues/62), replacing `can()` with `hasPermission()` inside `UsersTrait`, on the `isAdmin()` function.
+
 ## 1.5.1
 - Added constructors to `Permission` and `Group` models, to dynamically set the corresponding model tables.
 

--- a/src/Traits/UsersTrait.php
+++ b/src/Traits/UsersTrait.php
@@ -167,7 +167,7 @@ trait UsersTrait
      */
     public function isAdmin()
     {
-        return $this->can('admin');
+        return $this->hasPermission('admin');
     }
 
     /**

--- a/src/resources/views/_forms/users/add-group.blade.php
+++ b/src/resources/views/_forms/users/add-group.blade.php
@@ -38,7 +38,7 @@
                     {{ (in_array($g->id, old('groups')) ? 'selected' : '') }}
                         @endif
                 >
-                    {{ $permission->name }}
+                    {{ $g->name }}
                 </option>
             @endforeach
         @else


### PR DESCRIPTION
- Fix [#61](https://github.com/mateusjunges/laravel-acl/issues/61)
- Fix [#62](https://github.com/mateusjunges/laravel-acl/issues/62), replacing `can()` with `hasPermission()` inside `UsersTrait`, on the `isAdmin()` function.
