### PR TITLE
Add Support for Laravel 6

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /vendor
 .idea
 composer.lock
+.phpunit.result.cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,50 @@
 language: php
 
 php:
-  - 7.1
   - 7.2
   - 7.3
   - 7.4snapshot
 
 matrix:
+  fast_finish: true
+  include:
+    - php: 7.2
+      env: LARAVEL='5.6.*' TESTBENCH='3.6.*' COMPOSER_FLAGS='--prefer-lowest'
+    - php: 7.2
+      env: LARAVEL='5.6.*' TESTBENCH='3.6.*' COMPOSER_FLAGS='--prefer-stable'
+    - php: 7.2
+      env: LARAVEL='5.7.*' TESTBENCH='3.7.*' COMPOSER_FLAGS='--prefer-lowest'
+    - php: 7.2
+      env: LARAVEL='5.7.*' TESTBENCH='3.7.*' COMPOSER_FLAGS='--prefer-stable'
+    - php: 7.2
+      env: LARAVEL='5.8.*' TESTBENCH='3.8.*' COMPOSER_FLAGS='--prefer-lowest'
+    - php: 7.2
+      env: LARAVEL='5.8.*' TESTBENCH='3.8.*' COMPOSER_FLAGS='--prefer-stable'
+    - php: 7.3
+      env: LARAVEL='5.6.*' TESTBENCH='3.6.*' COMPOSER_FLAGS='--prefer-lowest'
+    - php: 7.3
+      env: LARAVEL='5.6.*' TESTBENCH='3.6.*' COMPOSER_FLAGS='--prefer-stable'
+    - php: 7.3
+      env: LARAVEL='5.7.*' TESTBENCH='3.7.*' COMPOSER_FLAGS='--prefer-lowest'
+    - php: 7.3
+      env: LARAVEL='5.7.*' TESTBENCH='3.7.*' COMPOSER_FLAGS='--prefer-stable'
+    - php: 7.3
+      env: LARAVEL='5.8.*' TESTBENCH='3.8.*' COMPOSER_FLAGS='--prefer-lowest'
+    - php: 7.3
+      env: LARAVEL='5.8.*' TESTBENCH='3.8.*' COMPOSER_FLAGS='--prefer-stable'
+    - php: 7.3
+      env: LARAVEL='6.*' TESTBENCH='4.*' COMPOSER_FLAGS='--prefer-lowest'
+    - php: 7.3
+      env: LARAVEL='6.*' TESTBENCH='4.*' COMPOSER_FLAGS='--prefer-stable'
   allow_failures:
     - php: 7.4snapshot
 
-before_script:
+before_install:
   - travis_retry composer self-update
-  - travis_retry composer update ${COMPOSER_FLAGS} --no-interaction --prefer-source
+  - travis_retry composer require --no-update --no-interaction "laravel/framework:${LARAVEL}" "orchestra/testbench:${TESTBENCH}"
+
+install:
+  - travis_retry composer update ${COMPOSER_FLAGS} --prefer-dist --no-interaction --no-suggest
 
 script:
   - vendor/bin/phpunit --coverage-text --coverage-clover=coverage.clover

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,5 @@
 language: php
 
-php:
-  - 7.2
-  - 7.3
-  - 7.4snapshot
-
 matrix:
   fast_finish: true
   include:
@@ -13,19 +8,13 @@ matrix:
     - php: 7.2
       env: LARAVEL='5.6.*' TESTBENCH='3.6.*' COMPOSER_FLAGS='--prefer-stable'
     - php: 7.2
-      env: LARAVEL='5.7.*' TESTBENCH='3.7.*' COMPOSER_FLAGS='--prefer-lowest'
-    - php: 7.2
       env: LARAVEL='5.7.*' TESTBENCH='3.7.*' COMPOSER_FLAGS='--prefer-stable'
     - php: 7.2
       env: LARAVEL='5.8.*' TESTBENCH='3.8.*' COMPOSER_FLAGS='--prefer-lowest'
     - php: 7.2
       env: LARAVEL='5.8.*' TESTBENCH='3.8.*' COMPOSER_FLAGS='--prefer-stable'
     - php: 7.3
-      env: LARAVEL='5.6.*' TESTBENCH='3.6.*' COMPOSER_FLAGS='--prefer-lowest'
-    - php: 7.3
       env: LARAVEL='5.6.*' TESTBENCH='3.6.*' COMPOSER_FLAGS='--prefer-stable'
-    - php: 7.3
-      env: LARAVEL='5.7.*' TESTBENCH='3.7.*' COMPOSER_FLAGS='--prefer-lowest'
     - php: 7.3
       env: LARAVEL='5.7.*' TESTBENCH='3.7.*' COMPOSER_FLAGS='--prefer-stable'
     - php: 7.3
@@ -36,6 +25,15 @@ matrix:
       env: LARAVEL='6.*' TESTBENCH='4.*' COMPOSER_FLAGS='--prefer-lowest'
     - php: 7.3
       env: LARAVEL='6.*' TESTBENCH='4.*' COMPOSER_FLAGS='--prefer-stable'
+    - php: 7.4snapshot
+      env: LARAVEL='5.6.*' TESTBENCH='3.6.*' COMPOSER_FLAGS='--prefer-stable'
+    - php: 7.4snapshot
+      env: LARAVEL='5.7.*' TESTBENCH='3.7.*' COMPOSER_FLAGS='--prefer-stable'
+    - php: 7.4snapshot
+      env: LARAVEL='5.8.*' TESTBENCH='3.8.*' COMPOSER_FLAGS='--prefer-stable'
+    - php: 7.4snapshot
+      env: LARAVEL='6.*' TESTBENCH='4.*' COMPOSER_FLAGS='--prefer-stable'
+
   allow_failures:
     - php: 7.4snapshot
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to `mateusjunges/laravel-acl` will be documented in this file.
 
+## 2.1.0
+- Update dependencies for Laravel 6
+- Drop support for Laravel 5.5 and older, and PHP 7.1 and older. (They can use v2.0 of this package until they upgrade.)
+- Version 2.1.0 and greater of this package require PHP 7.2 and higher.
+
 ## 2.0.3
 - Fix composer.json dependencies for laravel 6.0
 

--- a/README.md
+++ b/README.md
@@ -52,10 +52,20 @@ Or add this line in your `composer.json`, inside of the `require` section:
 ``` json
 {
     "require": {
-        "mateusjunges/laravel-acl": "2.0.*",
+        "mateusjunges/laravel-acl": "2.1.*",
     }
 }
 ```
+
+> For Laravel v5.5 or lower, use the version 2.0 of this package:
+>``` json
+>{
+>    "require": {
+>        "mateusjunges/laravel-acl": "2.0.*",
+>    }
+>}
+>```
+
 then run ` composer install `
 
 After installing the laravel-acl package, register the service provider in

--- a/composer.json
+++ b/composer.json
@@ -12,13 +12,13 @@
     ],
     "homepage": "https://github.com/mateusjunges/laravel-acl",
     "require": {
-        "php": ">=7.0",
-        "illuminate/auth": "5.4.*|5.5.*|5.6.*|5.7.*|5.8.*|^6.0",
-        "illuminate/database": "5.4.*|5.5.*|5.6.*|5.7.*|5.8.*|^6.0"
+        "php": "^7.2",
+        "illuminate/auth": "^5.7|^5.8|^6.0",
+        "illuminate/database": "^5.7|^5.8|^6.0"
     },
     "require-dev": {
-        "orchestra/testbench": "~3.4.2|~3.5.0|~3.6.0|~3.7.0",
-        "phpunit/phpunit": "^5.7|6.2|^7.0",
+        "orchestra/testbench": "^3.7|^3.8",
+        "phpunit/phpunit": "^7.0|^8.0",
         "predis/predis": "^1.1"
     },
     "license": "MIT",

--- a/composer.json
+++ b/composer.json
@@ -13,11 +13,11 @@
     "homepage": "https://github.com/mateusjunges/laravel-acl",
     "require": {
         "php": "^7.2",
-        "illuminate/auth": "^5.7|^5.8|^6.0",
-        "illuminate/database": "^5.7|^5.8|^6.0"
+        "illuminate/auth": "^5.6|^5.7|^5.8|^6.0",
+        "illuminate/database": "^5.6|^5.7|^5.8|^6.0"
     },
     "require-dev": {
-        "orchestra/testbench": "^3.7|^3.8",
+        "orchestra/testbench": "^3.6|^3.7|^3.8",
         "phpunit/phpunit": "^7.0|^8.0",
         "predis/predis": "^1.1"
     },

--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,7 @@
     "require": {
         "php": "^7.2",
         "illuminate/auth": "^5.6|^5.7|^5.8|^6.0",
+        "illuminate/support": "^5.6|^5.7|^5.8|^6.0",
         "illuminate/database": "^5.6|^5.7|^5.8|^6.0"
     },
     "require-dev": {

--- a/src/Events/GroupSaving.php
+++ b/src/Events/GroupSaving.php
@@ -15,7 +15,7 @@ class GroupSaving
     /**
      * Create a new event instance.
      *
-     * @param $attributes
+     * @param $group
      */
     public function __construct($group)
     {

--- a/src/Events/PermissionSaving.php
+++ b/src/Events/PermissionSaving.php
@@ -15,7 +15,7 @@ class PermissionSaving
     /**
      * Create a new event instance.
      *
-     * @param $attributes
+     * @param $permission
      */
     public function __construct($permission)
     {

--- a/tests/Commands/InstallCommandTest.php
+++ b/tests/Commands/InstallCommandTest.php
@@ -8,7 +8,7 @@ class InstallCommandTest extends TestCase
 {
     private $migrationsPath = 'migrations/vendor/junges/acl';
 
-    public function setUp()
+    public function setUp() : void
     {
         parent::setUp();
     }

--- a/tests/Exceptions/ExceptionsTest.php
+++ b/tests/Exceptions/ExceptionsTest.php
@@ -9,7 +9,7 @@ use Illuminate\Database\QueryException;
 
 class ExceptionsTest extends TestCase
 {
-    public function setUp()
+    public function setUp() : void
     {
         parent::setUp();
     }

--- a/tests/Middlewares/HierarchicalPermissionsMiddlewareTest.php
+++ b/tests/Middlewares/HierarchicalPermissionsMiddlewareTest.php
@@ -7,7 +7,7 @@ use Illuminate\Support\Facades\Auth;
 
 class HierarchicalPermissionsMiddlewareTest extends MiddlewareTestCase
 {
-    public function setUp()
+    public function setUp() : void
     {
         parent::setUp();
     }

--- a/tests/Middlewares/MiddlewareTestCase.php
+++ b/tests/Middlewares/MiddlewareTestCase.php
@@ -33,7 +33,7 @@ class MiddlewareTestCase extends TestCase
      */
     protected $hierarchicalMiddleware;
 
-    public function setUp()
+    public function setUp() : void
     {
         parent::setUp();
         $this->permissionMiddleware = new PermissionMiddleware($this->app);

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -67,7 +67,7 @@ class TestCase extends Orchestra
     /**
      * Set up the tests.
      */
-    public function setUp()
+    public function setUp() : void
     {
         parent::setUp();
 

--- a/tests/Traits/GroupPermissionsTest.php
+++ b/tests/Traits/GroupPermissionsTest.php
@@ -7,7 +7,7 @@ use Junges\ACL\Tests\TestCase;
 
 class GroupPermissionsTest extends TestCase
 {
-    public function setUp()
+    public function setUp() : void
     {
         parent::setUp();
     }

--- a/tests/Traits/GroupUsersTest.php
+++ b/tests/Traits/GroupUsersTest.php
@@ -7,7 +7,7 @@ use Junges\ACL\Tests\TestCase;
 
 class GroupUsersTest extends TestCase
 {
-    public function setUp()
+    public function setUp() : void
     {
         parent::setUp();
     }

--- a/tests/Traits/GroupsTrait/HasAllPermissionsMethodTest.php
+++ b/tests/Traits/GroupsTrait/HasAllPermissionsMethodTest.php
@@ -7,7 +7,7 @@ use Junges\ACL\Tests\Permission;
 
 class HasAllPermissionsMethodTest extends TestCase
 {
-    public function setUp()
+    public function setUp() : void
     {
         parent::setUp();
     }

--- a/tests/Traits/GroupsTrait/HasAnyPermissionMethodTest.php
+++ b/tests/Traits/GroupsTrait/HasAnyPermissionMethodTest.php
@@ -7,7 +7,7 @@ use Junges\ACL\Tests\Permission;
 
 class HasAnyPermissionMethodTest extends TestCase
 {
-    public function setUp()
+    public function setUp() : void
     {
         parent::setUp();
     }

--- a/tests/Traits/GroupsTrait/HasPermissionMethodTest.php
+++ b/tests/Traits/GroupsTrait/HasPermissionMethodTest.php
@@ -7,7 +7,7 @@ use Junges\ACL\Tests\Permission;
 
 class HasPermissionMethodTest extends TestCase
 {
-    public function setUp()
+    public function setUp() : void
     {
         parent::setUp();
     }

--- a/tests/Traits/GroupsTrait/RemoveUserMethodTest.php
+++ b/tests/Traits/GroupsTrait/RemoveUserMethodTest.php
@@ -7,7 +7,7 @@ use Junges\ACL\Tests\TestCase;
 
 class RemoveUserMethodTest extends TestCase
 {
-    public function setUp()
+    public function setUp() : void
     {
         parent::setUp();
     }

--- a/tests/Traits/GroupsTrait/RevokeAllPermissionsMethodTest.php
+++ b/tests/Traits/GroupsTrait/RevokeAllPermissionsMethodTest.php
@@ -7,7 +7,7 @@ use Junges\ACL\Tests\TestCase;
 
 class RevokeAllPermissionsMethodTest extends TestCase
 {
-    public function setUp()
+    public function setUp() : void
     {
         parent::setUp();
     }

--- a/tests/Traits/GroupsTrait/SyncPermissionsMethodTest.php
+++ b/tests/Traits/GroupsTrait/SyncPermissionsMethodTest.php
@@ -6,7 +6,7 @@ use Junges\ACL\Tests\TestCase;
 
 class SyncPermissionsMethodTest extends TestCase
 {
-    public function setUp()
+    public function setUp() : void
     {
         parent::setUp();
     }

--- a/tests/Traits/UserGroupsTest.php
+++ b/tests/Traits/UserGroupsTest.php
@@ -7,7 +7,7 @@ use Junges\ACL\Tests\TestCase;
 
 class UserGroupsTest extends TestCase
 {
-    public function setUp()
+    public function setUp() : void
     {
         parent::setUp();
     }

--- a/tests/Traits/UsersTrait/GetAllPermissionsMethodTest.php
+++ b/tests/Traits/UsersTrait/GetAllPermissionsMethodTest.php
@@ -6,7 +6,7 @@ use Junges\ACL\Tests\TestCase;
 
 class GetAllPermissionsMethodTest extends TestCase
 {
-    public function setUp()
+    public function setUp() : void
     {
         parent::setUp();
     }

--- a/tests/Traits/UsersTrait/HasAllGroupsMethodTest.php
+++ b/tests/Traits/UsersTrait/HasAllGroupsMethodTest.php
@@ -7,7 +7,7 @@ use Junges\ACL\Tests\TestCase;
 
 class HasAllGroupsMethodTest extends TestCase
 {
-    public function setUp()
+    public function setUp() : void
     {
         parent::setUp();
     }

--- a/tests/Traits/UsersTrait/HasAllPermissionsMethodTest.php
+++ b/tests/Traits/UsersTrait/HasAllPermissionsMethodTest.php
@@ -7,7 +7,7 @@ use Junges\ACL\Tests\Permission;
 
 class HasAllPermissionsMethodTest extends TestCase
 {
-    public function setUp()
+    public function setUp() : void
     {
         parent::setUp();
     }

--- a/tests/Traits/UsersTrait/HasAnyGroupMethodTest.php
+++ b/tests/Traits/UsersTrait/HasAnyGroupMethodTest.php
@@ -7,7 +7,7 @@ use Junges\ACL\Tests\Permission;
 
 class HasAnyGroupMethodTest extends TestCase
 {
-    public function setUp()
+    public function setUp() : void
     {
         parent::setUp();
     }

--- a/tests/Traits/UsersTrait/HasAnyPermissionMethodTest.php
+++ b/tests/Traits/UsersTrait/HasAnyPermissionMethodTest.php
@@ -7,7 +7,7 @@ use Junges\ACL\Tests\Permission;
 
 class HasAnyPermissionMethodTest extends TestCase
 {
-    public function setUp()
+    public function setUp() : void
     {
         parent::setUp();
     }

--- a/tests/Traits/UsersTrait/HasDirectPermissionsMethodTest.php
+++ b/tests/Traits/UsersTrait/HasDirectPermissionsMethodTest.php
@@ -7,7 +7,7 @@ use Junges\ACL\Tests\Permission;
 
 class HasDirectPermissionsMethodTest extends TestCase
 {
-    public function setUp()
+    public function setUp() : void
     {
         parent::setUp();
     }

--- a/tests/Traits/UsersTrait/HasPermissionMethodTest.php
+++ b/tests/Traits/UsersTrait/HasPermissionMethodTest.php
@@ -7,7 +7,7 @@ use Junges\ACL\Tests\Permission;
 
 class HasPermissionMethodTest extends TestCase
 {
-    public function setUp()
+    public function setUp() : void
     {
         parent::setUp();
     }

--- a/tests/Traits/UsersTrait/HasPermissionThroughGroupMethodTest.php
+++ b/tests/Traits/UsersTrait/HasPermissionThroughGroupMethodTest.php
@@ -7,7 +7,7 @@ use Junges\ACL\Tests\Permission;
 
 class HasPermissionThroughGroupMethodTest extends TestCase
 {
-    public function setUp()
+    public function setUp() : void
     {
         parent::setUp();
     }

--- a/tests/Traits/UsersTrait/PermissionViaGroupsMethodTest.php
+++ b/tests/Traits/UsersTrait/PermissionViaGroupsMethodTest.php
@@ -6,7 +6,7 @@ use Junges\ACL\Tests\TestCase;
 
 class PermissionViaGroupsMethodTest extends TestCase
 {
-    public function setUp()
+    public function setUp() : void
     {
         parent::setUp();
     }

--- a/tests/Traits/UsersTrait/RevokeAllGroupsMethodTest.php
+++ b/tests/Traits/UsersTrait/RevokeAllGroupsMethodTest.php
@@ -7,7 +7,7 @@ use Junges\ACL\Tests\TestCase;
 
 class RevokeAllGroupsMethodTest extends TestCase
 {
-    public function setUp()
+    public function setUp() : void
     {
         parent::setUp();
     }

--- a/tests/Traits/UsersTrait/RevokeAllPermissionsTest.php
+++ b/tests/Traits/UsersTrait/RevokeAllPermissionsTest.php
@@ -7,7 +7,7 @@ use Junges\ACL\Tests\TestCase;
 
 class RevokeAllPermissionsTest extends TestCase
 {
-    public function setUp()
+    public function setUp() : void
     {
         parent::setUp();
     }

--- a/tests/Traits/UsersTrait/ScopeGroupTest.php
+++ b/tests/Traits/UsersTrait/ScopeGroupTest.php
@@ -9,7 +9,7 @@ use Junges\ACL\Exceptions\GroupDoesNotExistException;
 
 class ScopeGroupTest extends TestCase
 {
-    public function setUp()
+    public function setUp() : void
     {
         parent::setUp();
     }

--- a/tests/Traits/UsersTrait/ScopePermissionTest.php
+++ b/tests/Traits/UsersTrait/ScopePermissionTest.php
@@ -9,7 +9,7 @@ use Junges\ACL\Exceptions\PermissionDoesNotExistException;
 
 class ScopePermissionTest extends TestCase
 {
-    public function setUp()
+    public function setUp() : void
     {
         parent::setUp();
     }

--- a/tests/Traits/UsersTrait/SyncPermissionsMethodTest.php
+++ b/tests/Traits/UsersTrait/SyncPermissionsMethodTest.php
@@ -6,7 +6,7 @@ use Junges\ACL\Tests\TestCase;
 
 class SyncPermissionsMethodTest extends TestCase
 {
-    public function setUp()
+    public function setUp() : void
     {
         parent::setUp();
     }

--- a/tests/Traits/WildcardPermissionsTest.php
+++ b/tests/Traits/WildcardPermissionsTest.php
@@ -7,7 +7,7 @@ use Illuminate\Support\Facades\Auth;
 
 class WildcardPermissionsTest extends TestCase
 {
-    public function setUp()
+    public function setUp() : void
     {
         parent::setUp();
     }


### PR DESCRIPTION
- Update dependencies for Laravel 6
- Drop support for Laravel 5.5 and older, and PHP 7.1 and older. (They can use v2.0 of this package until they upgrade.)
- Version 2.1.0 and greater of this package require PHP 7.2 and higher.