### PR TITLE
Fix/issue 143 instatiate ignition

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,8 @@
     "require-dev": {
         "orchestra/testbench": "^3.6|^3.7|^3.8",
         "phpunit/phpunit": "^7.0|^8.0",
-        "predis/predis": "^1.1"
+        "predis/predis": "^1.1",
+        "facade/ignition": "^1.4"
     },
     "license": "MIT",
     "authors": [

--- a/src/ACLServiceProvider.php
+++ b/src/ACLServiceProvider.php
@@ -116,17 +116,15 @@ class ACLServiceProvider extends ServiceProvider
      */
     public function registerSolutionProviders(): void
     {
-        if (! $this->app->runningUnitTests()) {
-            $this->app->make(SolutionProviderRepository::class)->registerSolutionProviders([
-                \Junges\ACL\Exceptions\Solutions\Providers\MissingUsersTraitSolutionProvider::class,
-                \Junges\ACL\Exceptions\Solutions\Providers\MissingGroupsTraitSolutionProvider::class,
-                \Junges\ACL\Exceptions\Solutions\Providers\MissingPermissionsTraitSolutionProvider::class,
-                \Junges\ACL\Exceptions\Solutions\Providers\MissingACLWildcardsTraitSolutionProvider::class,
-                \Junges\ACL\Exceptions\Solutions\Providers\NotInstalledSolutionProvider::class,
-                \Junges\ACL\Exceptions\Solutions\Providers\GroupDoesNotExistSolutionProvider::class,
-                \Junges\ACL\Exceptions\Solutions\Providers\PermissionDoesNotExistSolutionProvider::class,
-            ]);
-        }
+        $this->app->make(SolutionProviderRepository::class)->registerSolutionProviders([
+            \Junges\ACL\Exceptions\Solutions\Providers\MissingUsersTraitSolutionProvider::class,
+            \Junges\ACL\Exceptions\Solutions\Providers\MissingGroupsTraitSolutionProvider::class,
+            \Junges\ACL\Exceptions\Solutions\Providers\MissingPermissionsTraitSolutionProvider::class,
+            \Junges\ACL\Exceptions\Solutions\Providers\MissingACLWildcardsTraitSolutionProvider::class,
+            \Junges\ACL\Exceptions\Solutions\Providers\NotInstalledSolutionProvider::class,
+            \Junges\ACL\Exceptions\Solutions\Providers\GroupDoesNotExistSolutionProvider::class,
+            \Junges\ACL\Exceptions\Solutions\Providers\PermissionDoesNotExistSolutionProvider::class,
+        ]);
     }
 
     /**

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -5,6 +5,7 @@ namespace Junges\ACL\Tests;
 use Junges\ACL\ACLServiceProvider;
 use Junges\ACL\ACLAuthServiceProvider;
 use Illuminate\Database\Schema\Blueprint;
+use Facade\Ignition\IgnitionServiceProvider;
 use Orchestra\Testbench\TestCase as Orchestra;
 
 class TestCase extends Orchestra
@@ -93,6 +94,7 @@ class TestCase extends Orchestra
         return [
             ACLServiceProvider::class,
             ACLAuthServiceProvider::class,
+            IgnitionServiceProvider::class,
         ];
     }
 


### PR DESCRIPTION
This is to fix the bug of #143, which was introduced in v2.2.0. 

I have been able to reproduce the issue by pulling the `facade/ignition` composer requirement from the main composer file of a laravel project. `laravel == v6.3.0`

This makes sense as because the `laravel-acl` package now makes use of the `facade/ignition-contracts`, which has an interface that that is used to make the solution providers for the package available to ignition, unfortunately the interface is instantiated as a singleton from the main flare package, and without that it is not available to the normal laravel container/app.

For this reason, the initial travis builds failed, and were bypassed under the basis that most apps using this would be using ignition already, although it is only included in `new` installs, and not ones that have continued using the whoops error pages and not chosen to upgrade to ignition error pages.


I have now ensured that the tests for the ignition solutions are able to be instantiated, meaning that at least the package is installed and, will give users the ignition solutions, it may override there default error pages, but it does support back to laravel 5.5.

Should close #143.