### PR TITLE
Fix published migration file names

### DIFF
--- a/src/Providers/ACLServiceProvider.php
+++ b/src/Providers/ACLServiceProvider.php
@@ -57,8 +57,8 @@ class ACLServiceProvider extends ServiceProvider
         ], 'acl-config');
 
         $this->publishes([
-            __DIR__ . '/../../database/migrations/create_permissions_table.php' => $this->getMigrationFilename('create_acl_permissions_table.php', 1),
-            __DIR__ . '/../../database/migrations/create_groups_table.php' => $this->getMigrationFilename('create_acl_groups_table.php', 2),
+            __DIR__ . '/../../database/migrations/create_permissions_table.php' => $this->getMigrationFilename('create_permissions_table.php', 1),
+            __DIR__ . '/../../database/migrations/create_groups_table.php' => $this->getMigrationFilename('create_groups_table.php', 2),
             __DIR__ . '/../../database/migrations/create_model_has_permissions_table.php' => $this->getMigrationFilename('create_model_has_permissions_table.php', 3),
             __DIR__ . '/../../database/migrations/create_model_has_groups_table.php' => $this->getMigrationFilename('create_model_has_groups_table.php', 4),
             __DIR__ . '/../../database/migrations/create_group_has_permissions_table.php' => $this->getMigrationFilename('create_group_has_permissions_table.php', 5),


### PR DESCRIPTION
Mismatching name between class name and filename for Permissions and Groups table.
This causes   "Cannot declare class Create<name>Table, because the name is already in use" when executing "artisan migrate".