### PR TITLE
Fix migration table names

### DIFF
--- a/database/migrations/create_model_has_groups_table.php
+++ b/database/migrations/create_model_has_groups_table.php
@@ -41,7 +41,7 @@ class CreateModelHasGroupsTable extends Migration
 
     public function down()
     {
-        $userHasGroupsTable = config('acl.tables.user_has_groups', 'user_has_groups');
+        $userHasGroupsTable = config('acl.tables.model_has_groups', 'model_has_groups');
         Schema::dropIfExists($userHasGroupsTable);
     }
 }

--- a/database/migrations/create_model_has_groups_table.php
+++ b/database/migrations/create_model_has_groups_table.php
@@ -41,7 +41,7 @@ class CreateModelHasGroupsTable extends Migration
 
     public function down()
     {
-        $userHasGroupsTable = config('acl.tables.model_has_groups', 'model_has_groups');
-        Schema::dropIfExists($userHasGroupsTable);
+        $modelHasGroupsTable = config('acl.tables.model_has_groups', 'model_has_groups');
+        Schema::dropIfExists($modelHasGroupsTable);
     }
 }

--- a/database/migrations/create_model_has_permissions_table.php
+++ b/database/migrations/create_model_has_permissions_table.php
@@ -41,7 +41,7 @@ class CreateModelHasPermissionsTable extends Migration
 
     public function down()
     {
-        $userHasPermissionTable = config('acl.tables.user_has_permissions', 'user_has_permissions');
+        $userHasPermissionTable = config('acl.tables.model_has_permissions', 'model_has_permissions');
         Schema::dropIfExists($userHasPermissionTable);
     }
 }

--- a/database/migrations/create_model_has_permissions_table.php
+++ b/database/migrations/create_model_has_permissions_table.php
@@ -41,7 +41,7 @@ class CreateModelHasPermissionsTable extends Migration
 
     public function down()
     {
-        $userHasPermissionTable = config('acl.tables.model_has_permissions', 'model_has_permissions');
-        Schema::dropIfExists($userHasPermissionTable);
+        $modelHasPermissionTable = config('acl.tables.model_has_permissions', 'model_has_permissions');
+        Schema::dropIfExists($modelHasPermissionTable);
     }
 }


### PR DESCRIPTION
There's an inconsistency on table and variable name for the reverse migration script on https://github.com/mateusjunges/laravel-acl/blob/58468724f6597caba71feeecb507b9d7bdc7df86/database/migrations/create_model_has_groups_table.php#L44 and https://github.com/mateusjunges/laravel-acl/blob/58468724f6597caba71feeecb507b9d7bdc7df86/database/migrations/create_model_has_permissions_table.php#L44

I found that maybe the names have not been changed since https://github.com/mateusjunges/laravel-acl/pull/236 changed `user_has_permissions` to `model_has_permissions`.

I ran to the issue when was trying to refresh the migration and got error saying that the `model_has_permissions` table was already existed.